### PR TITLE
Rename class CustomLayout22 to CustomLayout so the example works.

### DIFF
--- a/WideCollectionViewLayout/CustomLayout.swift
+++ b/WideCollectionViewLayout/CustomLayout.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 
-class CustomLayout22: UICollectionViewFlowLayout {
+class CustomLayout: UICollectionViewFlowLayout {
     
     
     var numberOfItemsPerRow: Int = 3 {


### PR DESCRIPTION
Corrects a typo into the flow layout class name, which stops your example from working.
